### PR TITLE
added dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "rokumura7"
+      - "lilycoco"


### PR DESCRIPTION
## Major changes
Added dependabot.yml for checking outdated dependecies.

## References
https://docs.github.com/ja/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates

## Memo
> By default, Dependabot checks for new versions on Monday.

Yes, I know that but I wanna note it explicitly.